### PR TITLE
Remove trimming of space from requirements

### DIFF
--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -47,7 +47,7 @@ module CompactIndex
     end
 
     def join_multiple(requirements)
-      requirements.gsub(/[[:space:]]/, "").split(",").sort.join("&")
+      requirements.split(", ").sort.join("&")
     end
   end
 end

--- a/spec/compact_index_spec.rb
+++ b/spec/compact_index_spec.rb
@@ -83,9 +83,9 @@ describe CompactIndex do
     it "dependencies have platform" do
       param = [build_version(:number => "1.0.1", :dependencies => [
                                CompactIndex::Dependency.new("a", "=1.1", "jruby", "abc123"),
-                               CompactIndex::Dependency.new("b", "=1.2", "darwin-13", "abc123"),
+                               CompactIndex::Dependency.new("b", "= 1.2", "darwin-13", "abc123"),
                              ])]
-      expect(CompactIndex.info(param)).to eq("---\n1.0.1 a:=1.1-jruby,b:=1.2-darwin-13|checksum:sum+test_gem+1.0.1\n")
+      expect(CompactIndex.info(param)).to eq("---\n1.0.1 a:=1.1-jruby,b:= 1.2-darwin-13|checksum:sum+test_gem+1.0.1\n")
     end
 
     it "show ruby required version" do
@@ -95,7 +95,7 @@ describe CompactIndex do
 
     it "show ruby required version with multiple requirements" do
       param = [build_version(:number => "1.0.1", :ruby_version => "< 2.5, >=2.2")]
-      expect(CompactIndex.info(param)).to eq("---\n1.0.1 |checksum:sum+test_gem+1.0.1,ruby:<2.5&>=2.2\n")
+      expect(CompactIndex.info(param)).to eq("---\n1.0.1 |checksum:sum+test_gem+1.0.1,ruby:< 2.5&>=2.2\n")
     end
 
     it "show rubygems required version" do


### PR DESCRIPTION
also fixes token used for split.
rubygems.org (Dependency) and rubygems (Gem::Requirement) use `, `
to join list of requirements.

updated dep test to capture intended behaviour of preserving space
in requirements.