### PR TITLE
Add timestamp arg to version file create function

### DIFF
--- a/lib/compact_index/versions_file.rb
+++ b/lib/compact_index/versions_file.rb
@@ -24,11 +24,11 @@ module CompactIndex
       created_at_header(@path) || Time.at(0).to_datetime
     end
 
-    def create(gems)
+    def create(gems, ts = Time.now.iso8601)
       gems.sort!
 
       File.open(@path, "w") do |io|
-        io.write "created_at: #{Time.now.iso8601}\n---\n"
+        io.write "created_at: #{ts}\n---\n"
         io.write gem_lines(gems)
       end
     end

--- a/spec/versions_file_spec.rb
+++ b/spec/versions_file_spec.rb
@@ -92,6 +92,17 @@ gem_b 1.0 info+test_gem+1.0
         expect(file.open.read).to include("test 1.3.0,2.2,1.1.1,1.1.1,2.1.2 info+test_gem+2.1.2")
       end
     end
+
+    context "create with ts" do
+      file          = Tempfile.new
+      versions_file = CompactIndex::VersionsFile.new(file.path)
+      ts            = Time.new(1999, 9, 9).iso8601
+
+      it "is used in created_at header" do
+        versions_file.create([], ts)
+        expect(file.open.read).to start_with("created_at: #{ts}")
+      end
+    end
   end
 
   describe "#updated_at" do


### PR DESCRIPTION
we want to use the same timestamp used in db query to fetch the data.
previously, versions updated between the time we queried the db
and file creation were skipped.