### PR TITLE
Upgrade macos image to macos-14

### DIFF
--- a/.github/workflows/rubygems.yml
+++ b/.github/workflows/rubygems.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os:
           - { name: Ubuntu, value: ubuntu-22.04 }
-          - { name: macOS, value: macos-12 }
+          - { name: macOS, value: macos-14 }
           - { name: Windows, value: windows-2022 }
 
         ruby:
@@ -33,7 +33,7 @@ jobs:
 
         include:
           - ruby: { name: "3.2", value: 3.2.2 }
-            os: { name: macOS, value: macos-12 }
+            os: { name: macOS, value: macos-14 }
 
           - ruby: { name: jruby-9.4, value: jruby-9.4.2.0 }
             os: { name: Ubuntu, value: ubuntu-22.04 }


### PR DESCRIPTION
## What was the end-user or developer problem that led to this PR?

Nothing, but I saw the deprecation:

> A brownout will take place on November 4, 14:00 UTC - November 5,
> 00:00 UTC to raise awareness of the upcoming macOS-12 environment
> removal. For more details, see
> https://github.com/actions/runner-images/issues/10721

And I though I'd fix it.

## What is your fix for the problem, implemented in this PR?

Bump macos version in CI.

## Make sure the following tasks are checked

- [x] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [x] Write code to solve the problem
- [x] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)
