### PR TITLE
Add support for an /info_checksums endpoint

### DIFF
--- a/lib/compact_index.rb
+++ b/lib/compact_index.rb
@@ -21,6 +21,10 @@ module CompactIndex
     gem_names.join("\n").prepend("---\n") << "\n"
   end
 
+  def self.info_checksums(versions_file, gems = nil, calculate_info_checksums: false)
+    versions_file.contents(gems, :calculate_info_checksums => calculate_info_checksums)
+  end
+
   # Returns the versions file content argumented with some extra gems
   # @param versions_file [CompactIndex::VersionsFile] which will be used as a base response
   # @param gems [Array] an optional list of [CompactIndex::Gem] to be appended on the end
@@ -45,8 +49,8 @@ module CompactIndex
   #   rails 0.0.1,0.1.0 00fd5c36764f4ec1e8adf1c9adaada55
   #   sinatra 0.1.1,0.1.2,0.1.3 46f0a24d291725736216b4b6e7412be6
   #   ```
-  def self.versions(versions_file, gems = nil, args = {})
-    versions_file.contents(gems, args)
+  def self.versions(versions_file, gems = nil, **kwargs)
+    versions_file.contents(gems, **kwargs)
   end
 
   # Formats the versions information of a gem, to be display in the `/info/gemname` endpoint.

--- a/spec/compact_index_spec.rb
+++ b/spec/compact_index_spec.rb
@@ -37,6 +37,19 @@ describe CompactIndex do
     end
   end
 
+  describe ".info_checksums" do
+    it "delegates to VersionsFile#content" do
+      file = Tempfile.new("versions-endpoint")
+      versions_file = CompactIndex::VersionsFile.new(file.path, :only_info_checksums => true)
+      gems = [CompactIndex::Gem.new("test", [build_version])]
+      expect(
+        CompactIndex.info_checksums(versions_file, gems)
+      ).to eq(
+        versions_file.contents(gems)
+      )
+    end
+  end
+
   describe ".info" do
     it "without dependencies" do
       param = [build_version(:number => "1.0.1")]


### PR DESCRIPTION
This is /versions but without the versions list

Since bundler/rubygems only use the name/checksum in /versions, we can use a significantly smaller file that is also easier to parse

Signed-off-by: Samuel Giddins <segiddins@segiddins.me>

<!--
Thanks so much for the contribution!

Note that you must abide by the [code of conduct](https://github.com/rubygems/rubygems/blob/master/CODE_OF_CONDUCT.md) to contribute to this project.

To make reviewing this PR a bit easier, please fill out answers to the following questions.
-->

## What was the end-user or developer problem that led to this PR?

<!-- Write a clear and complete description of the problem -->

## What is your fix for the problem, implemented in this PR?

<!-- Explain the fix being implemented. Include any diagnosis you run to
determine the cause of the issue and your conclusions. If you considered other
alternatives, explain why you end up choosing the current implementation -->

## Make sure the following tasks are checked

- [ ] Describe the problem / feature
- [ ] Write [tests](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#tests) for features and bug fixes
- [ ] Write code to solve the problem
- [ ] Make sure you follow the [current code style](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#code-formatting) and [write meaningful commit messages without tags](https://github.com/rubygems/rubygems/blob/master/bundler/doc/development/PULL_REQUESTS.md#commit-messages)