### PR TITLE
Add optional created_at field to GemVersion

### DIFF
--- a/lib/compact_index/dependency.rb
+++ b/lib/compact_index/dependency.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CompactIndex
-  Dependency = Struct.new(:gem, :version, :platform, :checksum) do
+  Dependency = Struct.new(:gem, :version, :platform, :checksum) do # rubocop:disable Lint/StructNewOverride
     def version_and_platform
       if platform.nil? || platform == "ruby"
         version

--- a/lib/compact_index/dependency.rb
+++ b/lib/compact_index/dependency.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CompactIndex
-  Dependency = Struct.new(:gem, :version, :platform, :checksum) do # rubocop:disable Lint/StructNewOverride
+  Dependency = Struct.new(:gem, :version, :platform, :checksum) do
     def version_and_platform
       if platform.nil? || platform == "ruby"
         version

--- a/lib/compact_index/gem_version.rb
+++ b/lib/compact_index/gem_version.rb
@@ -2,7 +2,8 @@
 
 module CompactIndex
   GemVersion = Struct.new(:number, :platform, :checksum, :info_checksum,
-                          :dependencies, :ruby_version, :rubygems_version) do
+                          :dependencies, :ruby_version, :rubygems_version,
+                          :created_at) do
     def number_and_platform
       if platform.nil? || platform == "ruby"
         number
@@ -25,6 +26,7 @@ module CompactIndex
       line = "#{number_and_platform} #{deps_line}|checksum:#{checksum}"
       line << ",ruby:#{ruby_version_line}" if ruby_version && ruby_version != ">= 0"
       line << ",rubygems:#{rubygems_version_line}" if rubygems_version && rubygems_version != ">= 0"
+      line << ",created_at:#{created_at}" if created_at
       line
     end
 

--- a/spec/compact_index_spec.rb
+++ b/spec/compact_index_spec.rb
@@ -125,7 +125,8 @@ describe CompactIndex do
 
     it "show created_at with other requirements" do
       param = [build_version(:number => "1.0.1", :ruby_version => ">1.9", :created_at => "2024-05-01T12:00:00Z")]
-      expect(CompactIndex.info(param)).to eq("---\n1.0.1 |checksum:sum+test_gem+1.0.1,ruby:>1.9,created_at:2024-05-01T12:00:00Z\n")
+      expected = "---\n1.0.1 |checksum:sum+test_gem+1.0.1,ruby:>1.9,created_at:2024-05-01T12:00:00Z\n"
+      expect(CompactIndex.info(param)).to eq(expected)
     end
 
     it "omits created_at when nil" do

--- a/spec/compact_index_spec.rb
+++ b/spec/compact_index_spec.rb
@@ -117,5 +117,20 @@ describe CompactIndex do
       param = [build_version(:number => "1.0.1", :platform => "jruby")]
       expect(CompactIndex.info(param)).to eq("---\n1.0.1-jruby |checksum:sum+test_gem+1.0.1\n")
     end
+
+    it "show created_at timestamp" do
+      param = [build_version(:number => "1.0.1", :created_at => "2024-05-01T12:00:00Z")]
+      expect(CompactIndex.info(param)).to eq("---\n1.0.1 |checksum:sum+test_gem+1.0.1,created_at:2024-05-01T12:00:00Z\n")
+    end
+
+    it "show created_at with other requirements" do
+      param = [build_version(:number => "1.0.1", :ruby_version => ">1.9", :created_at => "2024-05-01T12:00:00Z")]
+      expect(CompactIndex.info(param)).to eq("---\n1.0.1 |checksum:sum+test_gem+1.0.1,ruby:>1.9,created_at:2024-05-01T12:00:00Z\n")
+    end
+
+    it "omits created_at when nil" do
+      param = [build_version(:number => "1.0.1")]
+      expect(CompactIndex.info(param)).not_to include("created_at")
+    end
   end
 end

--- a/spec/support/versions.rb
+++ b/spec/support/versions.rb
@@ -9,5 +9,6 @@ def build_version(args = {})
   dependencies = args.fetch(:dependencies, nil)
   ruby_version = args.fetch(:ruby_version, nil)
   rubygems_version = args.fetch(:rubygems_version, nil)
-  CompactIndex::GemVersion.new(number, platform, checksum, info_checksum, dependencies, ruby_version, rubygems_version)
+  created_at = args.fetch(:created_at, nil)
+  CompactIndex::GemVersion.new(number, platform, checksum, info_checksum, dependencies, ruby_version, rubygems_version, created_at)
 end

--- a/spec/support/versions.rb
+++ b/spec/support/versions.rb
@@ -10,5 +10,7 @@ def build_version(args = {})
   ruby_version = args.fetch(:ruby_version, nil)
   rubygems_version = args.fetch(:rubygems_version, nil)
   created_at = args.fetch(:created_at, nil)
-  CompactIndex::GemVersion.new(number, platform, checksum, info_checksum, dependencies, ruby_version, rubygems_version, created_at)
+  CompactIndex::GemVersion.new(
+    number, platform, checksum, info_checksum, dependencies, ruby_version, rubygems_version, created_at
+  )
 end


### PR DESCRIPTION
## Problem

Supply chain attacks targeting package registries are a growing concern. Other package managers have already shipped minimum age features — [npm](https://github.com/npm/cli/releases/tag/v11.10.0), [pnpm](https://pnpm.io/supply-chain-security), and [yarn](https://github.com/yarnpkg/berry/issues/6899) all allow users to reject recently published versions during resolution.

Bundler currently has no equivalent. Adding one requires knowing when each gem version was published, but the compact index has no publication timestamp. Without it, clients must make a separate V1 API call per gem (`/api/v1/versions/<gem>.json`) — adding seconds of latency and hitting the RubyGems.org rate limit (10 req/s) on projects with 50+ gems.

## Solution

Add an optional `created_at` field to `GemVersion`. When populated, it is appended to the requirements section of the `/info` line:

```
1.0.0 rack:>= 1.0|checksum:abc123,ruby:>= 2.7.0,created_at:2024-05-01T12:00:00Z
```

When `nil`, the field is omitted entirely:
- **Full backwards compatibility** — old clients ignore unknown requirement fields, old servers simply don't populate it
- **No flag or query parameter needed** — the server decides whether to include it
- **Zero extra API calls** — clients read `created_at` from data already fetched during resolution

## Changes

- `GemVersion` struct: added `created_at` as 8th field (default `nil`)
- `GemVersion#to_line`: appends `created_at:<timestamp>` when present
- `build_version` test helper: accepts optional `:created_at` kwarg
- 3 new specs: timestamp present, timestamp with other requirements, omitted when nil

## Downstream

- [rubygems/rubygems.org#6380](https://github.com/rubygems/rubygems.org/pull/6380) — passes `created_at` to compact index output